### PR TITLE
Istio install no longer works with 1.4.6. Need to update to 1.4.7

### DIFF
--- a/setup/config
+++ b/setup/config
@@ -2,7 +2,7 @@
 
 export KNATIVE_VERSION="0.13.0"
 
-export ISTIO_VERSION="1.4.6"
+export ISTIO_VERSION="1.4.7"
 
 export PROJECT_ID="knative-atamel"
 


### PR DESCRIPTION
# Install Istio CRDs
kubectl apply -f "https://raw.githubusercontent.com/knative/serving/master/third_party/istio-${ISTIO_VERSION}/istio-crds.yaml"
error: unable to read URL "https://raw.githubusercontent.com/knative/serving/master/third_party/istio-1.4.6/istio-crds.yaml", server reported 404 Not Found, status code=404

# Install Istio
kubectl apply -f "https://raw.githubusercontent.com/knative/serving/master/third_party/istio-${ISTIO_VERSION}/istio-minimal.yaml"
error: unable to read URL "https://raw.githubusercontent.com/knative/serving/master/third_party/istio-1.4.6/istio-minimal.yaml", server reported 404 Not Found, status code=404