### PR TITLE
Switch to 'https://storage.cloud.google.com/[BUCKET_NAME]/[OBJECT_NAME]

### DIFF
--- a/eventing/processing-pipelines/bigquery/notifier/python/app.py
+++ b/eventing/processing-pipelines/bigquery/notifier/python/app.py
@@ -61,7 +61,7 @@ def notify(bucket, name):
     app.logger.info(f"notify with bucket '{bucket}' and name '{name}'")
 
     to_emails = os.environ.get('TO_EMAILS')
-    image_url = f'https://storage.googleapis.com/{bucket}/{name}'
+    image_url = f'https://storage.cloud.google.com/{bucket}/{name}'
     app.logger.info(f"Sending email to '{to_emails}''")
 
     message = Mail(


### PR DESCRIPTION
Switch to `https://storage.cloud.google.com/[BUCKET_NAME]/[OBJECT_NAME]` for the URL to send, based on https://cloud.google.com/storage/docs/request-endpoints#cookieauth.