### PR TITLE
Fix broker creation step

### DIFF
--- a/docs/helloworldeventing.md
+++ b/docs/helloworldeventing.md
@@ -31,7 +31,13 @@ We need to inject a Broker in the namespace where we want to receive messages.
 Let's use the default namespace.
 
 ```bash
-kubectl label ns default eventing.knative.dev/injection=enabled
+kubectl create -f - <<EOF
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: default
+  namespace: default
+EOF
 ```
 
 You should see a Broker in the namespace:


### PR DESCRIPTION
When I ran the `kubectl label` command I didn't see a Broker appear in my default namespace. I [asked on Slack](https://knative.slack.com/archives/C93E33SN8/p1604609960410200) and people told me this was the recommended way to create a broker now.